### PR TITLE
fix arm_state issue and display idle info after record ends

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with flowshutter.  If not, see <https://www.gnu.org/licenses/>.
 from machine import Pin, UART, Timer
-import crsf, oled, target, sony_multiport
+import crsf, vars, oled, target, sony_multiport
 import uasyncio as asyncio
 from time import sleep
 
@@ -24,28 +24,33 @@ uart1, _, _, button1, button2 = target.init_pins()
 fc_arm_packet, fc_disarm_packet = crsf.init_packet()
 state = ['idle', 'starting', 'recording', 'stopping', 'stopped']
 
+arm_state = "disarm"
 button1_press_count = 0
 button1_trigger = 0
 button2_press_count = 0
 button2_trigger = 0
-arm_flag=0
-switching_flag = 0
+
+def change_arm(state):
+    if state == "arm":
+        state = "disarm"
+    elif state == "disarm":
+        state = "arm"
+    return state
+
 def check_button(t):
     global button1_press_count
     global button1_trigger
     global button2_press_count
     global button2_trigger
-    global switching_flag
+    global arm_state
     if button1.value() == 0:
         if button1_press_count <=100:
             button1_press_count += 1
         else:
             button1_press_count = 0
             button1_trigger = 1
-            if current_state == state[0]:
-                switching_flag = 1
             print('button1 tiggered', button1_trigger)
-            print('switching_flag', switching_flag)
+            arm_state = change_arm(arm_state)
     else:
         button1_press_count = 0
     if button2.value() == 0:
@@ -54,15 +59,16 @@ def check_button(t):
         else:
             button2_press_count = 0
             button2_trigger = 1
+            print('button2 triggered', button2_trigger)
 
 timer0 = Timer(0)
 timer0.init(period=5, mode=Timer.PERIODIC, callback=check_button)
 
 def send_crsf_packet(t):
-    global arm_flag
-    if arm_flag == 1:
+    #print(arm_state)
+    if vars.arm_state == "arm":
         uart1.write(fc_arm_packet)
-    else:
+    elif vars.arm_state == "disarm":
         uart1.write(fc_disarm_packet)
 timer1 = Timer(1)
 timer1.init(period=4, mode=Timer.PERIODIC, callback=send_crsf_packet)

--- a/sony_multiport.py
+++ b/sony_multiport.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with flowshutter.  If not, see <https://www.gnu.org/licenses/>.
 import uasyncio as asyncio
-import target,oled
+import vars,target,oled
 def init_multiport_packet():
     rcd_prs = b'#7100*'
     rcd_rls = b'#7110*'
@@ -34,27 +34,30 @@ async def uart_handler():
     rcd_prs, rcd_rls, cm_hdsk, cm_hdsk_ack, cm_rcd_start, cm_rcd_start_ack, cm_rcd_stop, cm_rcd_stop_ack = init_multiport_packet()
     _, uart2, _, _, _ = target.init_pins()
     oled1 = oled.oled_init()
-    global switching_flag
-    global arm_flag
     swriter = asyncio.StreamWriter(uart2, {})
     sreader = asyncio.StreamReader(uart2)
     while True:
         res = await sreader.read(n=-1)
         print('Cam sent:', res)
-        if res == cm_hdsk: # receive handshake
+
+        if res == cm_hdsk:                          # receive handshake
             await asyncio.sleep_ms(10)
-            await swriter.awrite(cm_hdsk_ack) # send handshake ack to camera
-        elif res == cm_rcd_start:
+            await swriter.awrite(cm_hdsk_ack)       # send handshake ack to camera
+
+        elif res == cm_rcd_start:                   # receive record start
             await asyncio.sleep_ms(9)# I don't know if this timing is good, should look into it later
-            switching_flag = 0
-            arm_flag = 1
-            await swriter.awrite(cm_rcd_start_ack) # send record start ack to camera
+            vars.arm_state = "arm"                       # Arm the FC
+            print(vars.arm_state)
+            await swriter.awrite(cm_rcd_start_ack)  # send record start ack to camera
             print('camera is recording')
             oled.show_arm_info(oled1)
-        elif res == cm_rcd_stop:
-            await asyncio.sleep_ms(10)
-            switching_flag = 0
-            arm_flag = 0
-            await swriter.awrite(cm_rcd_stop_ack) # send record stop ack to camera
+
+        elif res == cm_rcd_stop:                    # receive record stop
+            await asyncio.sleep_ms(9)
+            vars.arm_state = "disarm"                    # disarm the FC
+            print(vars.arm_state)
+            await swriter.awrite(cm_rcd_stop_ack)   # send record stop ack to camera
             print('camera is stopped')
             oled.show_disarm_info(oled1)
+            await asyncio.sleep_ms(3000)
+            oled.show_idle_info(oled1)              # back to idle info

--- a/vars.py
+++ b/vars.py
@@ -1,0 +1,19 @@
+# Flowshutter
+# Copyright (C) 2021  Hugo Chiang
+
+# Flowshutter is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# Flowshutter is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+# You should have received a copy of the GNU Affero General Public License
+# along with flowshutter.  If not, see <https://www.gnu.org/licenses/>.
+## ARM and DISARM global flag
+arm_state = "disarm"
+
+## Other settings is coming soon!


### PR DESCRIPTION
Fix unable to arm FC issue introduced by #6 , also change to use "arm" and "disarm" strings to describe the ARM state of the FC.