### PR TITLE
Add user setting system

### DIFF
--- a/buttons.py
+++ b/buttons.py
@@ -14,27 +14,28 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with flowshutter.  If not, see <https://www.gnu.org/licenses/>.
 import vars, target
-button1, button2 = target.init_buttons()
+button_page, button_enter = target.init_buttons()
 
-button1_press_count = 0
-button2_press_count = 0
+button_page_press_count = 0
+button_enter_press_count = 0
 
 def check(t):
-    global button1_press_count
-    global button2_press_count
-    if button1.value() == 0:
-        if button1_press_count <=100:   # dead time is 100*5 = 500ms = 0.5s
-            button1_press_count += 1
+    global button_page_press_count
+    global button_enter_press_count
+    if button_page.value() == 0:
+        if button_page_press_count <=20:   # dead time is 20*5 = 100ms = 0.1s
+            button_page_press_count += 1
         else:
-            button1_press_count = 0
-            vars.button1_trigger = "yes"
-            print('button1 tiggered', vars.button1_trigger)
+            button_page_press_count = 0
+            vars.button_page = "pressed"
+            print('button_page tiggered', vars.button_page)
+            
     else:
-        button1_press_count = 0
-    if button2.value() == 0:
-        if button2_press_count <=100:
-            button2_press_count += 1
+        button_page_press_count = 0
+    if button_enter.value() == 0:
+        if button_enter_press_count <=50:
+            button_enter_press_count += 1
         else:
-            button2_press_count = 0
-            vars.button2_trigger = "yes"
-            print('button2 triggered', vars.button2_trigger)
+            button_enter_press_count = 0
+            vars.button_enter = "pressed"
+            print('button_enter triggered', vars.button_enter)

--- a/main.py
+++ b/main.py
@@ -14,11 +14,11 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with flowshutter.  If not, see <https://www.gnu.org/licenses/>.
 from machine import Pin, Timer
-import buttons, crsf, vars, sony_multiport,menu
+import buttons, crsf, vars, sony_multiport,menu,settings
 import uasyncio as asyncio
 from time import sleep
 
-import json
+settings.read()
 
 timer0 = Timer(0)
 timer0.init(period=5, mode=Timer.PERIODIC, callback=buttons.check)

--- a/menu.py
+++ b/menu.py
@@ -13,28 +13,79 @@
 
 # You should have received a copy of the GNU Affero General Public License
 # along with flowshutter.  If not, see <https://www.gnu.org/licenses/>.
-import oled, vars
+import oled, vars, json
 oled1 = oled.init()
 
 def update(t):
+    
     if vars.shutter_state == "idle":
-        if vars.button1_trigger == "yes":
-            vars.button1_trigger = "no"
+        ## idle ==> battery
+        if vars.button_page == "pressed":
+            vars.button_page = "released"
             oled.display_menu_battery(oled1)
             vars.shutter_state = "menu_battery"
             print("show battery")
+    
     elif vars.shutter_state == "menu_battery":
-        if vars.button1_trigger == "yes":
-            vars.button1_trigger = "no"
-            oled.display_menu_settings(oled1)
-            vars.shutter_state = "menu_test"
-    elif vars.shutter_state == "menu_test":
-        if vars.button2_trigger == "yes":
-            vars.button2_trigger = "no"
+        ## battery ==> device mode
+        if vars.button_page == "pressed":
+            vars.button_page = "released"
+            oled.display_menu_device_mode(oled1)
+            vars.shutter_state = "menu_device_mode"
+    
+    elif vars.shutter_state == "menu_device_mode":
+        if vars.button_enter == "pressed":
+            vars.button_enter = "released"
 
+            if vars.device_mode == "slave":
+                vars.device_mode = "master"
+            elif vars.device_mode == "master":
+                vars.device_mode = "slave"
+            oled.display_menu_device_mode(oled1)
 
-        if vars.button1_trigger == "yes":
-            vars.button1_trigger = "no"
+        ## device mode ==> inject mode
+        if vars.button_page == "pressed":
+            vars.button_page = "released"
+            oled.display_menu_inject_mode(oled1)
+            vars.shutter_state = "menu_inject_mode"
+
+    elif vars.shutter_state == "menu_inject_mode":
+        if vars.button_enter == "pressed":
+            vars.button_enter = "released"
+
+            if vars.inject_mode == "off":
+                vars.inject_mode = "on"
+            elif vars.inject_mode == "on":
+                vars.inject_mode = "off"
+            oled.display_menu_inject_mode(oled1)
+
+        ## inject mode ==> camera protocol
+        if vars.button_page == "pressed":
+            vars.button_page = "released"
+            oled.display_menu_camera_protocol(oled1)
+            vars.shutter_state = "menu_camera_protocol"
+
+    elif vars.shutter_state == "menu_camera_protocol":
+        if vars.button_enter == "pressed":
+            vars.button_enter = "released"
+
+            if vars.camera_protocol == "mtp":
+                vars.camera_protocol = "usb"
+            elif vars.camera_protocol == "usb":
+                vars.camera_protocol = "mtp"
+            ## this is not correct ATM, need to fix in future
+            oled.display_menu_camera_protocol(oled1)
+            
+        if vars.button_page == "pressed":
+            vars.button_page = "released"
             oled.display_idle_info(oled1)
             vars.shutter_state = "idle"
             print("show idle")
+            with open("settings.json", "w") as f:
+                settings = {
+                    "device_mode": vars.device_mode,
+                    "inject_mode": vars.inject_mode,
+                    "camera_protocol": vars.camera_protocol
+                    }
+                json.dump(settings, f)
+                f.close()

--- a/oled.py
+++ b/oled.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with flowshutter.  If not, see <https://www.gnu.org/licenses/>.
 from machine import Pin, I2C
-import ssd1306, time, target
+import vars, ssd1306, time, target
 
 def draw_cam(display):
     # start flowshutter logo
@@ -252,10 +252,26 @@ def display_menu_battery(display):
 
     display.show()
 
-def display_menu_test(display):
+def display_menu_device_mode(display):
+    display.fill(0)
     draw_logo_idle(display)
-    display.text('Test Menu', 40, 0, 1)
-    display.text('button2', 40, 12, 1)
-    display.text('increase set', 40, 24, 1)
+    display.text('Device Mode', 40, 0, 1)
+    display.text("".join(tuple(vars.device_mode)), 40, 12, 1)
+    display.text('Next Marker', 40, 24, 1)
     display.show()
 
+def display_menu_inject_mode(display):
+    display.fill(0)
+    draw_logo_idle(display)
+    display.text('Marker Inj', 40, 0, 1)
+    display.text("".join(tuple(vars.inject_mode)), 40, 12, 1)
+    display.text('Next cam', 40, 24, 1)
+    display.show()
+
+def display_menu_camera_protocol(display):
+    display.fill(0)
+    draw_logo_idle(display)
+    display.text('Camera Protocol', 40, 0, 1)
+    display.text(''.join(tuple(vars.camera_protocol)), 40, 12, 1)
+    display.text('PAGE to save', 40, 24, 1)
+    display.show()

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,41 @@
+# Flowshutter
+# Copyright (C) 2021  Hugo Chiang
+
+# Flowshutter is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# Flowshutter is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+# You should have received a copy of the GNU Affero General Public License
+# along with flowshutter.  If not, see <https://www.gnu.org/licenses/>.
+
+def read():
+    import os
+    import json
+    import vars
+    try:
+        os.stat("settings.json")
+        with open("settings.json", "r") as f:
+            settings = json.load(f)
+            vars.device_mode = settings["device_mode"]
+            vars.inject_mode = settings["inject_mode"]
+            vars.camera_protocol = settings["camera_protocol"]
+            # print("settings loaded, value", vars.test)
+    except KeyError:
+        with open("settings.json", "w") as f:
+            settings = {
+                "device_mode": "slave",
+                "inject_mode": "off",
+                "camera_protocol": "mtp"
+                }
+            json.dump(settings, f)
+    except OSError:
+        with open("settings.json", "w") as f:
+            settings = {"device_mode":"slave","inject_mode":"off","camera_protocol":"mtp"}
+            # IDK what makes such difference here, but if I use the code above, then first two settings will be blocked.
+            json.dump(settings, f)

--- a/target.py
+++ b/target.py
@@ -24,9 +24,9 @@ def init_oled_i2c():
     return i2c
 
 def init_buttons():
-    button1 = Pin(15, Pin.IN, Pin.PULL_UP)
-    button2 = Pin(27, Pin.IN, Pin.PULL_UP)
-    return button1, button2
+    button_page = Pin(15, Pin.IN, Pin.PULL_UP)
+    button_enter = Pin(27, Pin.IN, Pin.PULL_UP)
+    return button_page, button_enter
 
 def init_uart2():
     uart2 = UART(2, baudrate = 9600, bits = 8, parity = 0,    stop = 1, tx = 25, rx = 26)

--- a/vars.py
+++ b/vars.py
@@ -23,8 +23,11 @@ shutter_state = "idle"
 # "recording"
 # "stopping"
 
-button1_trigger = "no"
-button2_trigger = "no"
+button_page = "released"
+button_enter = "released"
 ## Other settings is coming soon!
 
-somesetting = 1
+# user_settings:
+device_mode = "slave",
+inject_mode = "off",
+camera_protocol = "mtp"


### PR DESCRIPTION
This allows to change settings and store them after power off, so next time when the device was powered on, users no more need to change settings to what they want manually.

This also introduced a framework to manage different camera protocols like Sony multiport USB, LANC and more in an easier way.

One thing worth noting is if the shutter was accidentally dropped into the recording state, the unsaved settings might be lost. Further test needed.