### PR TITLE
Fix lockup issue caused by settings mismatch

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -26,19 +26,18 @@ def _load_():
         test = f.read()
         f.close()
 
-def _write_default_():
+def write_default():
     with open("settings.json", "w") as f:
         settings = {"device_mode":"SLAVE", "inject_mode":"OFF", "camera_protocol":"Sony MTP"}
         json.dump(settings, f)
         f.close()
     _load_()
-
 def read():
     try:
         _load_()
     except KeyError: # settings.json has new member(s)
         print("overwrite default settings")
-        _write_default_()
+        write_default()
     except OSError: # settings.json does not exist
         print("create default settings")
-        _write_default_()
+        write_default()

--- a/vars.py
+++ b/vars.py
@@ -37,7 +37,16 @@ inject_mode_range = ["OFF", "ON"]
 camera_protocol_range = ["Sony MTP", "New protocol"]
 
 def next(range, current):
-    if current == range[-1]:
-        return range[0]
-    else:
-        return range[range.index(current) + 1]
+    try:
+        index = range.index(current)
+        if index == len(range) - 1:
+            return range[0]
+        else:
+            return range[index + 1]
+    except ValueError:
+        import settings, oled
+        settings.write_default()
+        print("Error: settings.json is corrupted. Overwritten a new one.")
+        print("Please reboot the device.")
+        ## later there should implenment an error message on the OLED
+        settings.read()


### PR DESCRIPTION
If updated from an old version which have different settings map, then when try to change some device settings the `vars.next()` will show `ValueError`.

This PR adds protection in this case. Once the `ValueError` reports, it will overwrite a default `settings.json`, then a reboot is needed.

TODO: Add OLED warning info when this happens.