### PR TITLE
Add AP mode

### DIFF
--- a/ap.py
+++ b/ap.py
@@ -1,0 +1,27 @@
+# Flowshutter
+# Copyright (C) 2021  Hugo Chiang
+
+# Flowshutter is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# Flowshutter is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+# You should have received a copy of the GNU Affero General Public License
+# along with flowshutter.  If not, see <https://www.gnu.org/licenses/>.
+import network, vars
+
+ap = network.WLAN(network.AP_IF)
+ap.config(essid='Flowshutter', authmode=network.AUTH_WPA_WPA2_PSK, password='ilovehugo')
+
+def up():
+    vars.ap_state = "UP"
+    ap.active(True)
+
+def down():
+    vars.ap_state = "DOWN"
+    ap.active(False)

--- a/buttons.py
+++ b/buttons.py
@@ -28,7 +28,7 @@ def check(t):
         else:
             button_page_press_count = 0
             vars.button_page = "pressed"
-            print('button_page tiggered', vars.button_page)
+            print('button_page ', vars.button_page)
             
     else:
         button_page_press_count = 0
@@ -38,4 +38,4 @@ def check(t):
         else:
             button_enter_press_count = 0
             vars.button_enter = "pressed"
-            print('button_enter triggered', vars.button_enter)
+            print('button_enter ', vars.button_enter)

--- a/menu.py
+++ b/menu.py
@@ -33,6 +33,31 @@ def update(t):
             vars.button_page = "released"
             oled.display_menu_device_mode(oled1)
             vars.shutter_state = "menu_device_mode"
+        
+        if vars.button_enter == "pressed":
+            vars.button_enter = "released"
+            oled.display_menu_ap_mode(oled1)
+            vars.shutter_state = "menu_ap_mode"
+
+    elif vars.shutter_state == "menu_ap_mode":
+        import ap
+
+        if vars.button_enter == "pressed":
+            vars.button_enter = "released"
+            if vars.ap_state == "down":
+                ap.up()
+                oled.display_menu_ap_mode(oled1)
+            else:
+                ap.down()
+                oled.display_menu_ap_mode(oled1)
+
+
+        ## ap mode ==> battery
+        if vars.button_page == "pressed":
+            vars.button_page = "released"
+            oled.display_menu_battery(oled1)
+            vars.shutter_state = "idle"
+            print("show battery")
     
 
     elif vars.shutter_state == "menu_device_mode":

--- a/oled.py
+++ b/oled.py
@@ -277,3 +277,11 @@ def display_menu_camera_protocol(display):
     display.text("".join(tuple(vars.camera_protocol)), 34, 12, 1)
     display.text('PAGE to save', 34, 24, 1)
     display.show()
+
+def display_menu_ap_mode(display):
+    display.fill(0)
+    draw_logo_idle(display)
+    display.text('Access Point', 34, 0, 1)
+    display.text("".join(tuple(vars.ap_state)), 34, 12, 1)
+    display.text('NEXT Battery', 34, 24, 1)
+    display.show()

--- a/vars.py
+++ b/vars.py
@@ -23,9 +23,15 @@ shutter_state = "idle"
 # "recording"
 # "stopping"
 
+## button state
 button_page = "released"
 button_enter = "released"
+
+## WLAN state
+ap_state = "DOWN"
+wifi_state = "disconneted"
 ## Other settings is coming soon!
+
 
 # user_settings:
 version = "0.42" # this should be update firstly!


### PR DESCRIPTION
This PR adds a simple AP mode

The option was hidden under the battery menu. Ro enter this hidden menu, hit "ENT" under battery menu.

"ENT" to toggle AP up and down, "PAGE" to back to battery menu.

AP's ssid is `Flowshutter`, password is `ilovehugo` (for now).