### PR TITLE
Add MASTER/SLAVE mode

### DIFF
--- a/buttons.py
+++ b/buttons.py
@@ -16,6 +16,7 @@
 import vars, target
 button_page, button_enter = target.init_buttons()
 
+# two private variables
 button_page_press_count = 0
 button_enter_press_count = 0
 

--- a/crsf.py
+++ b/crsf.py
@@ -15,9 +15,9 @@
 # along with flowshutter.  If not, see <https://www.gnu.org/licenses/>.
 import crsf_gen,target, vars
 def init():
-    disarm_packet = crsf_gen.build_rc_packet(  992,992,189,992,189,992,992,992,
+    disarm_packet = crsf_gen.build_rc_packet(   992,992,189,992,189,992,992,992,
                                                 992,992,992,992,992,992,992,992)
-    arm_packet = crsf_gen.build_rc_packet(     992,992,189,992,1800,992,992,992,
+    arm_packet = crsf_gen.build_rc_packet(      992,992,189,992,1800,992,992,992,
                                                 992,992,992,992,992,992,992,992)
 
     uart1 = target.init_crsf_uart()

--- a/menu.py
+++ b/menu.py
@@ -19,6 +19,21 @@ oled1 = oled.init()
 def update(t):
     
     if vars.shutter_state == "idle":
+
+
+        if vars.button_enter == "pressed":
+            vars.button_enter = "released"
+            if vars.device_mode == "MASTER/SLAVE":
+
+                if vars.arm_state == "disarm":
+                    oled.display_arm_info(oled1)
+                    vars.arm_state = "arm"
+                else:
+                    oled.display_disarm_info(oled1)
+                    vars.arm_state = "disarm"
+
+
+
         ## idle ==> battery
         if vars.button_page == "pressed":
             vars.button_page = "released"

--- a/vars.py
+++ b/vars.py
@@ -35,7 +35,7 @@ wifi_state = "disconneted"
 
 
 # user_settings:
-version = "0.42" # this should be update firstly!
+version = "0.42" # when new user settings added, this should be update firstly!
 device_mode = "SLAVE"
 inject_mode = "OFF"
 camera_protocol = "Sony MTP"


### PR DESCRIPTION
Allow to start/stop record via flowshutter's button.

In the Sony MTP case, the recording state should still trigger by the camera's recording CMD instead of flowshutter's button. This need to be fixed in the future when the whole OLED update mechanism get refactored.