### PR TITLE
Add welcome state at powerup

### DIFF
--- a/oled.py
+++ b/oled.py
@@ -24,8 +24,7 @@ screen = _init_()
 
 def update(state):
     if state == "welcome":
-        #display_welcome()
-        _display_idle_()
+        _display_welcome_()
     elif state == "idle":
         _display_idle_()
     elif state == "starting":
@@ -215,6 +214,13 @@ def _draw_battery_():
     screen.pixel(112,5,0)
     screen.pixel(112,26,0)
     screen.pixel(93,26,0)
+
+def _display_welcome_():
+    screen.fill(0)
+    screen.text("Welcome to ",0,0,1)
+    screen.text("Gyroflow",0,10,1)
+    screen.text("Flowshutter",0,20,1)
+    screen.show()
 
 def _display_idle_():
     screen.fill(0)

--- a/ui.py
+++ b/ui.py
@@ -15,9 +15,12 @@
 # along with flowshutter.  If not, see <https://www.gnu.org/licenses/>.
 import ap, oled, vars, json, settings
 
+welcome_time_count = 0
+
 def update(t):
-    
-    if vars.shutter_state == "idle":
+    if vars.shutter_state == "welcome":
+        _welcome_()
+    elif vars.shutter_state == "idle":
         _idle_()
     elif vars.shutter_state == "starting":
         _starting_()
@@ -40,6 +43,15 @@ def _check_oled_():# check if we need to update the OLED
     if vars.previous_state != vars.shutter_state:
         vars.previous_state = vars.shutter_state
         oled.update(vars.shutter_state)
+
+def _welcome_():
+    global welcome_time_count
+    _check_oled_()
+    # welcome auto switch
+    if welcome_time_count <= 100:
+        welcome_time_count = welcome_time_count + 1
+    else:
+        vars.shutter_state = "idle"
 
 def _idle_():
     _check_oled_()

--- a/vars.py
+++ b/vars.py
@@ -20,7 +20,7 @@ arm_state = "disarm" #the state of the ARM/DISARM
 
 ## flowshutter working state
 previous_state = "blank"
-shutter_state = "idle"
+shutter_state = "welcome"
 # "starting"
 # "recording"
 # "stopping"


### PR DESCRIPTION
Add a new state `welcome` at powerup. It will automatically transfer to `idle` state after 4sec.

The next step for this topic is to add gyroflow official logo to the OLED lib.