### PR TITLE
Add internel switch triggering and voltage level triggering

### DIFF
--- a/simple_cam.py
+++ b/simple_cam.py
@@ -1,0 +1,35 @@
+# Flowshutter
+# Copyright (C) 2021  Hugo Chiang
+
+# Flowshutter is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# Flowshutter is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+# You should have received a copy of the GNU Affero General Public License
+# along with flowshutter.  If not, see <https://www.gnu.org/licenses/>.
+import target, vars
+
+cciw = target.init_cc_internal_switch()
+
+def toggle_internal_switch():
+    cciw.value(0)
+    print("low voltage level")
+    cciw.value(1)
+    print("high-impedance state")
+
+v_pin = target.init_v_level_pin()
+
+def toggle_cc_voltage_level():
+    if vars.shutter_state == "recording":
+        v_pin.value(1)
+        print("high voltage level")
+    else:
+        v_pin.value(0)
+        print("low voltage level")
+

--- a/target.py
+++ b/target.py
@@ -41,3 +41,11 @@ def init_buttons():
 def init_uart2():
     uart2 = UART(2, baudrate = 9600, bits = 8, parity = 0,    stop = 1, tx = 25, rx = 26)
     return uart2
+
+def init_cc_internal_switch():
+    cciw = Pin(25, Pin.OUT, Pin.OPEN_DRAIN)
+    return cciw
+
+def init_v_level_pin():
+    v_pin = Pin(26, Pin.OUT, value = 0)
+    return v_pin

--- a/ui.py
+++ b/ui.py
@@ -13,7 +13,7 @@
 
 # You should have received a copy of the GNU Affero General Public License
 # along with flowshutter.  If not, see <https://www.gnu.org/licenses/>.
-import wlan,battery, buttons,oled, vars, json, settings, sony_multi
+import wlan,battery, buttons,oled, vars, json, settings, simple_cam, sony_multi
 
 welcome_time_count = 0
 udpate_count = 0
@@ -246,20 +246,43 @@ def _menu_inject_mode_():
         vars.shutter_state = "idle"
 
 def _rec_enter_():
-    if (vars.camera_protocol == "Sony MTP") & (vars.device_mode == "MASTER/SLAVE"):
+    if (vars.device_mode == "MASTER/SLAVE") & (vars.camera_protocol == "Sony MTP"):
         sony_multi.uart2.write(sony_multi.REC_PRESS)
         sony_multi.uart2.write(sony_multi.REC_RELEASE)
         if vars.shutter_state == "idle":
             vars.shutter_state = "starting"
         elif vars.shutter_state == "recording":
             vars.shutter_state = "stopping"
-    elif (vars.camera_protocol == "NO") & (vars.device_mode == "MASTER"):
-        if vars.shutter_state == "idle":
-            vars.shutter_state = "recording"
-            vars.arm_state = "arm"
-        elif vars.shutter_state == "recording":
-            vars.shutter_state = "idle"
-            vars.arm_state = "disarm"
+    
+    elif vars.device_mode == "MASTER":
+
+        if vars.camera_protocol == "Internel SW":
+            if vars.shutter_state == "idle":
+                vars.shutter_state = "recording"
+                simple_cam.toggle_internal_switch()
+                vars.arm_state = "arm"
+            elif vars.shutter_state == "recording":
+                vars.shutter_state = "idle"
+                simple_cam.toggle_internal_switch()
+                vars.arm_state = "disarm"
+
+        elif vars.camera_protocol == "RED V-level":
+            if vars.shutter_state == "idle":
+                vars.shutter_state = "recording"
+                simple_cam.toggle_cc_voltage_level()
+                vars.arm_state = "arm"
+            elif vars.shutter_state == "recording":
+                vars.shutter_state = "idle"
+                simple_cam.toggle_cc_voltage_level()
+                vars.arm_state = "disarm"
+
+        elif vars.camera_protocol == "NO":
+            if vars.shutter_state == "idle":
+                vars.shutter_state = "recording"
+                vars.arm_state = "arm"
+            elif vars.shutter_state == "recording":
+                vars.shutter_state = "idle"
+                vars.arm_state = "disarm"
 
 def _rec_page_():
     if vars.info == "recording":

--- a/vars.py
+++ b/vars.py
@@ -59,7 +59,7 @@ camera_protocol = "Sony MTP"
 ota_source = "GitHub"
 ota_channel = "stable"
 
-camera_protocol_range = ["Sony MTP", "NO"]
+camera_protocol_range = ["Sony MTP","Internel SW", "RED V-level", "NO"]
 device_mode_range = ["SLAVE", "MASTER/SLAVE"]
 inject_mode_range = ["OFF", "ON"]
 ota_source_range = ["GitHub", "Gitee"]
@@ -72,7 +72,7 @@ def update_camera_preset():# per camera protocol
     if camera_protocol == "Sony MTP":
         device_mode = "SLAVE"
         device_mode_range = ["SLAVE", "MASTER/SLAVE"]
-    elif camera_protocol == "NO":
+    elif camera_protocol == "NO" or camera_protocol == "Internel SW" or camera_protocol == "RED V-level":
         device_mode = "MASTER"
         device_mode_range = ["MASTER"]
 


### PR DESCRIPTION
This PR introduced two simple camera recording triggering mechanisms:

- `Internal SW`: Use GPIO to mimic the action of a switch short circuit. This mechanism is widely found in various cameras， including but not limited to:
    - Canon
    - Nikon
    - Kinefinity
    - BMPCC 4k/6k HDMI recording wire
- `RED V-level`: Use GPIO to change voltage level. Commonly seen on RED cameras. https://support.red.com/hc/en-us/articles/360044301953-DSMC-DSMC2-Remote-Start-Stop