### PR TITLE
Fix momentary ground behaviour

### DIFF
--- a/oled.py
+++ b/oled.py
@@ -211,7 +211,7 @@ def _display_starting_():
     _draw_cam_()
     screen.text('Starting', 34, 0, 1)
     screen.text('FC Disarmed', 34, 12, 1)
-    screen.text('Sony start', 34, 24, 1)
+    screen.text('Camera start', 34, 24, 1)
     screen.show()
 
 def _display_recording_():
@@ -227,7 +227,7 @@ def _display_stopping_():
     _draw_cam_()
     screen.text('Stopping', 34, 0, 1)
     screen.text('FC Armed', 34, 12, 1)
-    screen.text('Sony ending', 34, 24, 1)
+    screen.text('Camera stop', 34, 24, 1)
     screen.show()
 
 def _display_battery_():

--- a/simple_cam.py
+++ b/simple_cam.py
@@ -17,11 +17,8 @@ import target, vars
 
 switch = target.init_momentary_ground_pin()
 
-def toggle_internal_switch():
-    switch.value(0)
-    print("low voltage level")
-    switch.value(1)
-    print("high-impedance state")
+def toggle_internal_switch(value):
+    switch.value(value)
 
 schmitt = target.init_schmitt_trigger_pin()
 

--- a/target.py
+++ b/target.py
@@ -43,7 +43,7 @@ def init_uart2():
     return uart2
 
 def init_momentary_ground_pin():
-    switch = Pin(25, Pin.OUT, Pin.OPEN_DRAIN)
+    switch = Pin(25, Pin.OPEN_DRAIN, value = 1)
     return switch
 
 def init_schmitt_trigger_pin():

--- a/vars.py
+++ b/vars.py
@@ -52,7 +52,7 @@ oled_need_update = "no"
 
 
 # user_settings:
-version = "0.40" # when new user settings added, this should be update firstly!
+version = "0.50" # when new user settings added, this should be update firstly!
 device_mode = "SLAVE"
 inject_mode = "OFF"
 camera_protocol = "Sony MTP"


### PR DESCRIPTION
- Fix the wrong pin initialization
- Add 1s `starting` and `stopping` state between momentary ground `recording` and `idle` state to avoid potential issue.
- Increase version to v0.50