### PR TITLE
Fix RX loss issue inctroduced by 4.3 RC4

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,16 +14,18 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with flowshutter.  If not, see <https://www.gnu.org/licenses/>.
 from machine import Timer
+import machine as machine
 import crsf, vars, sony_multi,ui,settings
 import uasyncio as asyncio
 
+machine.freq(240000000)
 settings.read()
 
-timer0 = Timer(0) # 200Hz update rate
-timer0.init(period=5, mode=Timer.PERIODIC, callback=ui.update)
+timer0 = Timer(0) # 100Hz CRSF sender
+timer0.init(period=10, mode=Timer.PERIODIC, callback=crsf.send_packet)
 
-timer1 = Timer(1) # 200Hz CRSF sender
-timer1.init(period=5, mode=Timer.PERIODIC, callback=crsf.send_packet)
+timer1 = Timer(1) # 200Hz update rate
+timer1.init(period=5, mode=Timer.PERIODIC, callback=ui.update)
 
 if vars.camera_protocol == "Sony MTP":
     camera_uart_handler = sony_multi.uart_handler()

--- a/target.py
+++ b/target.py
@@ -30,7 +30,7 @@ def init_audio():
     return audio_pin
 
 def init_i2c():
-    i2c = SoftI2C(scl=Pin(22), sda=Pin(21),freq = 400000)
+    i2c = SoftI2C(scl=Pin(22), sda=Pin(21),freq = 800000)
     return i2c
 
 def init_buttons():

--- a/ui.py
+++ b/ui.py
@@ -23,17 +23,11 @@ ground_time_count = 0
 def update(t):          # UI tasks controller
     battery.read_vol()  # read the battery voltage
     buttons.check(t)    # check the buttons
-    _check_oled_()      # check if OLED needs update
     _check_shutter_state_() # check working state and assign handler
     _check_oled_()      # check if OLED needs update
 
 def _check_oled_():# check if we need to update the OLED
-    global udpate_count
-    if udpate_count >=1000:
-        udpate_count = 0
-        vars.oled_need_update = "yes"
-    else:
-        udpate_count = udpate_count +5
+
     if vars.previous_state != vars.shutter_state:
         vars.previous_state = vars.shutter_state
         vars.info = vars.shutter_state
@@ -164,6 +158,13 @@ def _stopping_():
         vars.button_page = "released"
 
 def _battery_():
+
+    global udpate_count
+    if udpate_count >=5000:
+        udpate_count = 0
+        vars.oled_need_update = "yes"
+    else:
+        udpate_count = udpate_count +5
 
     # page to camera protocol menu
     if vars.button_page == "pressed":


### PR DESCRIPTION
Betaflight 4.3.0 RC4 increases the sensitivity to the length of the gap between frames. So now we can't ARM the FC logger correctly due to `RX_loss` and/or `BAD_RX`. Here's the fix:
- Reduce I2C OLED writing time by:
    - increase MCU speed to 240MHz
    - increase I2C frequency to 800 000
- Reduce CRSF packet sender frequency to 100Hz
- Remove unnecessary OLED update

May lead to increased power consumption, but still needs to be observed.