### PR TITLE
Add reboot hint for changing camera protocol

### DIFF
--- a/oled.py
+++ b/oled.py
@@ -50,6 +50,8 @@ def update(info):
         _display_menu_device_mode_()
     elif info == "menu_inject_mode":
         _display_menu_inject_mode_()
+    elif info == "menu_reboot_hint":
+        _display_menu_reboot_hint_()
     elif info == "sony mtp ack":
         _show_sony_mtp_ack_()
 
@@ -282,6 +284,14 @@ def _display_menu_camera_protocol_():
     screen.text('Cam Protocol', 34, 0, 1)
     screen.text("".join(tuple(vars.camera_protocol)), 34, 12, 1)
     screen.text('Next Device', 34, 24, 1)
+    screen.show()
+
+def _display_menu_reboot_hint_():
+    screen.fill(0)
+    screen.fill_rect(2,1,124,30,1)
+    screen.fill_rect(6,4,116,24,0)
+    screen.text('Please reboot', 9, 6, 1)
+    screen.text('to apply', 32, 16, 1)
     screen.show()
 
 def _display_menu_device_mode_():

--- a/ui.py
+++ b/ui.py
@@ -57,6 +57,8 @@ def _check_shutter_state_():
         _menu_ota_channel_()
     elif vars.shutter_state == "menu_camera_protocol":
         _menu_camera_protocol_()
+    elif vars.shutter_state == "menu_reboot_hint":
+        _menu_reboot_hint_()
     elif vars.shutter_state == "menu_device_mode":
         _menu_device_mode_()
     elif vars.shutter_state == "menu_inject_mode":
@@ -210,13 +212,20 @@ def _menu_camera_protocol_():
         vars.button_enter = "released"
         vars.camera_protocol = vars.next(vars.camera_protocol_range, vars.camera_protocol)
         vars.update_camera_preset()
-        vars.oled_need_update = "yes"
+        vars.shutter_state = "menu_reboot_hint"
         settings.update()
 
     # page to device mode
     if vars.button_page == "pressed":
         vars.button_page = "released"
         vars.shutter_state = "menu_device_mode"
+
+def _menu_reboot_hint_():
+    
+    if (vars.button_enter == "pressed") or (vars.button_page == "pressed"):
+        vars.button_enter = "released"
+        vars.button_page = "released"
+        vars.shutter_state = "menu_camera_protocol"
 
 def _menu_device_mode_():
 

--- a/vars.py
+++ b/vars.py
@@ -52,7 +52,7 @@ oled_need_update = "no"
 
 
 # user_settings:
-version = "0.50" # when new user settings added, this should be update firstly!
+version = "0.51" # when new user settings added, this should be update firstly!
 device_mode = "SLAVE"
 inject_mode = "OFF"
 camera_protocol = "Sony MTP"


### PR DESCRIPTION
If camera protocol changed, flowshutter should be rebooted so for applying settings.