### PR TITLE
Fix misleading info/vars/functions/names around Schmitt Trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ At the same time you can try to DIY your own flowshutter hardware. We have two o
 
 - [x] Sony MULTI Terminal protocol
 - [x] Momentary Ground
-- [x] Schmitt trigger
-- [] Sony LANC protocol (WIP)
-- [] HDMI CEC protocol (WIP)
-- [] Others are on the way
+- [x] 3.3V Schmitt trigger
+- (WIP) 5V Schmitt trigger
+- (WIP) Sony LANC protocol
+- (WIP) HDMI CEC protocol
 
 For more information about support camera list, please check the [list](https://docs.gyroflow.xyz/logging/flowshutter/camera%20list/) on the [documentation website](https://docs.gyroflow.xyz/).
 

--- a/simple_cam.py
+++ b/simple_cam.py
@@ -17,16 +17,18 @@ import target, vars
 
 switch = target.init_momentary_ground_pin()
 
-def toggle_internal_switch(value):
+def momentary_ground(value):
+    # 1 High impedance (open drain)
+    # 0 Low voltage (tied to ground)
     switch.value(value)
 
-schmitt = target.init_schmitt_trigger_pin()
+schmitt_3v3 = target.init_schmitt_3v3_trigger_pin()
 
 def toggle_cc_voltage_level():
     if vars.shutter_state == "recording":
-        schmitt.value(1)
+        schmitt_3v3.value(1)
         print("high voltage level")
     else:
-        schmitt.value(0)
+        schmitt_3v3.value(0)
         print("low voltage level")
 

--- a/target.py
+++ b/target.py
@@ -46,6 +46,6 @@ def init_momentary_ground_pin():
     switch = Pin(25, Pin.OPEN_DRAIN, value = 1)
     return switch
 
-def init_schmitt_trigger_pin():
-    schmitt = Pin(26, Pin.OUT, value = 0)
-    return schmitt
+def init_schmitt_3v3_trigger_pin():
+    schmitt_3v3 = Pin(26, Pin.OUT, value = 0)
+    return schmitt_3v3

--- a/ui.py
+++ b/ui.py
@@ -94,7 +94,7 @@ def _starting_():
         if ground_time_count <1000:
             ground_time_count = ground_time_count + 5
         else:
-            simple_cam.toggle_internal_switch(1)
+            simple_cam.momentary_ground(1)
             vars.shutter_state = "recording"
             vars.arm_state = "arm"
             ground_time_count = 0
@@ -131,7 +131,7 @@ def _stopping_():
         if ground_time_count <1000:
             ground_time_count = ground_time_count + 5
         else:
-            simple_cam.toggle_internal_switch(1)
+            simple_cam.momentary_ground(1)
             vars.shutter_state = "idle"
             vars.arm_state = "disarm"
             ground_time_count = 0
@@ -269,13 +269,13 @@ def _rec_enter_():
         if vars.camera_protocol == "MMTRY GND":
             if vars.shutter_state == "idle":
                 vars.shutter_state = "starting"
-                simple_cam.toggle_internal_switch(0)
+                simple_cam.momentary_ground(0)
             elif vars.shutter_state == "recording":
                 vars.shutter_state = "stopping"
-                simple_cam.toggle_internal_switch(0)
+                simple_cam.momentary_ground(0)
 
 
-        elif vars.camera_protocol == "Schmitt trig":
+        elif vars.camera_protocol == "3V3 Schmitt":
             if vars.shutter_state == "idle":
                 vars.shutter_state = "recording"
                 simple_cam.toggle_cc_voltage_level()

--- a/vars.py
+++ b/vars.py
@@ -52,14 +52,14 @@ oled_need_update = "no"
 
 
 # user_settings:
-version = "0.51" # when new user settings added, this should be update firstly!
+version = "0.52" # when new user settings added, this should be update firstly!
 device_mode = "SLAVE"
 inject_mode = "OFF"
 camera_protocol = "Sony MTP"
 ota_source = "GitHub"
 ota_channel = "stable"
 
-camera_protocol_range = ["Sony MTP","MMTRY GND", "Schmitt trig", "NO"]
+camera_protocol_range = ["Sony MTP","MMTRY GND", "3V3 Schmitt", "NO"]
 device_mode_range = ["SLAVE", "MASTER/SLAVE"]
 inject_mode_range = ["OFF", "ON"]
 ota_source_range = ["GitHub", "Gitee"]
@@ -72,7 +72,7 @@ def update_camera_preset():# per camera protocol
     if camera_protocol == "Sony MTP":
         device_mode = "SLAVE"
         device_mode_range = ["SLAVE", "MASTER/SLAVE"]
-    elif camera_protocol == "NO" or camera_protocol == "MMTRY GND" or camera_protocol == "Schmitt trig":
+    elif camera_protocol == "NO" or camera_protocol == "MMTRY GND" or camera_protocol == "3V3 Schmitt":
         device_mode = "MASTER"
         device_mode_range = ["MASTER"]
 


### PR DESCRIPTION
I have only achieved the 3.3V Schmitt trigger, not 5V nor 12V. So rename them all.