### PR TITLE
Add check option (for CI)

### DIFF
--- a/src/sha.json
+++ b/src/sha.json
@@ -41,36 +41,32 @@
             "sha1": "d6bf43cbbecf2268eac005823bf502fac32b390b"
         },
         {
-            "name": "sha.json",
-            "sha1": "7e60bafd9895614ec703587d0e763de069f4d8b9"
-        },
-        {
             "name": "simple_cam.py",
-            "sha1": "ca21a36e00f0a9d243018f0f541200eef877e4e8"
+            "sha1": "46e4de8b2705366427853c18dc5522875ae1beb9"
         },
         {
             "name": "sony_multi.py",
-            "sha1": "90f5d53e7afd81648bdf7631ab7ce949202e31ff"
+            "sha1": "de3965f0203b18b6b12328f1b26049fe47c76dc4"
         },
         {
             "name": "ssd1306.py",
-            "sha1": "2a8a6f55073f33f25c61e9ffcc080dbcc88fe3e2"
+            "sha1": "ac1e735b4e7aeed1aa5aa9c07f885953c815a852"
         },
         {
             "name": "target.py",
-            "sha1": "0a001688e29c533b37653a48f59b0dcaa4bed2c2"
+            "sha1": "b8c26f4f6192232fc99ab133a9abb0832e8fcccd"
         },
         {
             "name": "ui.py",
-            "sha1": "c601f17c81f34c2a8e83b04a98b173f6f7f1352e"
+            "sha1": "203648534fe70fb59d89aa897fe74d64aa3b5d41"
         },
         {
             "name": "vars.py",
-            "sha1": "609fb3983e0ccbf21f1397bc0c024a121706c819"
+            "sha1": "a522c5594c0111daa9e7c0ce9586dd72c12172d0"
         },
         {
             "name": "wlan.py",
-            "sha1": "c5a61a6eae44937464f479c03659d3749e4f8020"
+            "sha1": "3c6691b3a701bb98b7433d9de51e8bb25cc898f8"
         }
     ]
 }

--- a/tools/gen_sha.py
+++ b/tools/gen_sha.py
@@ -13,10 +13,15 @@
 
 # You should have received a copy of the GNU Affero General Public License
 # along with flowshutter.  If not, see <https://www.gnu.org/licenses/>.
-import hashlib, json, os
+import hashlib, json, os, sys
 
-sha1_hash = hashlib.sha1()
+sha1 = hashlib.sha1()
 files = os.listdir("src/")
+
+try:
+    files.remove("sha.json")
+except ValueError:
+    pass
 
 # print(files)
 jtext = {"files":[]}
@@ -24,13 +29,22 @@ jtext = {"files":[]}
 for f in files:
     with open("src/"+f,"rb") as hf:
         for byte_block in iter(lambda: hf.read(4096),b""):
-            sha1_hash.update(byte_block)
-        # print(f,sha1_hash.hexdigest()) # for debug
-        jtext["files"].append({"name":f,"sha1":sha1_hash.hexdigest()})
+            sha1.update(byte_block)
+        # print(f,sha1.hexdigest()) # for debug
+        jtext["files"].append({"name":f,"sha1":sha1.hexdigest()})
 
 jdata = json.dumps(jtext,indent = 4, separators=(',', ': '))
+
+jdir = ""
+# print(len(sys.argv)) # for debug
+if len(sys.argv) > 1:
+    if sys.argv[1] == "check":
+        jdir = "check_sha.json"
+else:
+    jdir = "src/sha.json"
+    
 print("SHA1 of all files generated!")
-jfile = open("src/sha.json","w")
+jfile = open(jdir,"w")
 jfile.write(jdata)
 jfile.close()
 print("Update sha.json success!")


### PR DESCRIPTION
- Delete `sha.json` from the `files` list so to solve the wrong sha1 output.
- Add an option `check` to generate `check_sha` in the root directory, so for using this in CI later.