### PR TITLE
[OLED Driver] Split framebuffer by pages

### DIFF
--- a/src/oled.py
+++ b/src/oled.py
@@ -283,8 +283,15 @@ def _display_menu_ota_channel_():
 def _display_menu_ota_check_():
     screen.fill(0)
     screen.text('OTA Check', 34, 0, 1)
+    screen.text("".join(tuple(vars.ota_source))+"/"+"".join(tuple(vars.ota_channel)), 34, 12, 1)
     screen.text('Check update', 34, 24, 1)
     screen.show()
+
+def _display_menu_ota_update_():
+    screen.fill(0)
+    screen.text('OTA Update - Enter to start!', 0, 0, 1)
+    screen.text("Downloading xxx.py", 0, 12, 1)
+    screen.text("Please wait for downloading complete!", 0, 24, 1)
 
 def _display_menu_camera_protocol_():
     screen.fill(0)

--- a/src/sha.json
+++ b/src/sha.json
@@ -34,7 +34,7 @@
         },
         {
             "name": "oled.py",
-            "sha1": "885e1bc614dcbd1c8807a04cda72659c5791cb6e"
+            "sha1": "7242ee1548d185a8aaae00647336ff678c910ff0"
         },
         {
             "name": "ota.py",
@@ -54,7 +54,7 @@
         },
         {
             "name": "ssd1306.py",
-            "sha1": "b108dfc4151f5d3bbc03cc681974840352b90cb7"
+            "sha1": "adf8023a40022d0123b1646406d8bf4ccd28d33b"
         },
         {
             "name": "target.py",


### PR DESCRIPTION
It's time for a roundup of these OLED driver updates happening today.

The I2C OLED update will cause a ~12ms block in the current code. This is very difficult for us to accept - it will cause an `RX loss` warning on the flight controller and a series of unpredictable consequences.

This PR will split the original OLED refresh action from a full-frame refresh (512 bytes) to a four-sub-frame step-by-step refresh (128 bytes for each).

Although the PR did not improve the blocking situation, the original blocking task has been split into four blocking subtasks, which the queue scheduling method can be used to reorganize these tasks later to alleviate the blocking situation.