### PR TITLE
Add a simple schedular on timer1

### DIFF
--- a/src/sha.json
+++ b/src/sha.json
@@ -34,7 +34,7 @@
         },
         {
             "name": "main.py",
-            "sha1": "f69b945281b850337f299a620dcafe3bbf6e8989"
+            "sha1": "42adfc7030801d7bf3cfb0f2da47477dfadd18f9"
         },
         {
             "name": "oled.py",
@@ -50,11 +50,15 @@
         },
         {
             "name": "ssd1306.py",
-            "sha1": "4df295359b5c9df8354481850e8b1c509b226487"
+            "sha1": "5021a637caafa4a40cbc5b1a75379095c8096edd"
         },
         {
             "name": "target.py",
             "sha1": "428a1d07188c8bcb0ac4534e21514ab781984d5e"
+        },
+        {
+            "name": "task.py",
+            "sha1": "614fb9d8ab139e4b9965cec3586ad8048e69f27a"
         },
         {
             "name": "ui.py",
@@ -62,7 +66,7 @@
         },
         {
             "name": "vars.py",
-            "sha1": "a4658079d26ace0e133a9a479b383a6abf1beaa5"
+            "sha1": "f4e52a25a990e835ab24cb9bada0fce19c05f8be"
         },
         {
             "name": "wlan.py",

--- a/src/task.py
+++ b/src/task.py
@@ -13,23 +13,19 @@
 
 # You should have received a copy of the GNU Affero General Public License
 # along with flowshutter.  If not, see <https://www.gnu.org/licenses/>.
-from machine import Timer
-import machine as machine
-import task, vars, camera, ui, settings
-import uasyncio as asyncio
+import camera, crsf, vars, oled
 
-machine.freq(240000000)
-settings.read()
-# settings.apply()
+crsf = crsf.CRSF()
+oled = oled.screen
 
-timer0 = Timer(0) # 200Hz CRSF sender
-timer0.init(period=5, mode=Timer.PERIODIC, callback=task.schedular)
-
-timer1 = Timer(1) # 200Hz update rate
-timer1.init(period=5, mode=Timer.PERIODIC, callback=ui.update)
-
-if vars.camera_protocol == "Sony MTP":
-    camera_uart_handler = camera.Sony_multi().uart_handler()
-    loop = asyncio.get_event_loop()
-    loop.create_task(camera_uart_handler)
-    loop.run_forever()
+def schedular(t):
+    crsf.send_packet(t) # task1
+    if vars.oled_tasklist != []:
+        print("oled task not empty!")
+        print(vars.oled_tasklist)
+        i = vars.oled_tasklist[0]
+        oled.show_sub(i)
+        del vars.oled_tasklist[0]
+    else:
+        pass
+        # print("no oled task")

--- a/src/vars.py
+++ b/src/vars.py
@@ -17,7 +17,7 @@
 vol = 4.0
 ## ARM and DISARM global flag
 arm_state = "disarm" #the state of the ARM/DISARM
-# arm_time = 0        # the time of the ARM
+oled_tasklist = []
 # "arm"
 
 ## flowshutter working state


### PR DESCRIPTION
This PR makes a small tweak to the OLED driver and adds a small simple scheduler on timer1 to eliminate the blocking problem as described earlier. https://github.com/gyroflow/flowshutter/pull/114

- Split the original `show(self)` into `show(self)` and `show_sub(self, i)`
    - `show_sub` is similar to the previous `show`, splitting the entire `framebuffer` by page, the difference is that `show_sub` can perform display operations according to the specified page
    - new `show()` is now used to create new `show_sub()` subtasks in `oled_tasklist`
- Add a scheduler on timer1 to replace bare CRSF sender
    - the first task is always the CRSF packet sender
    - the second task depends on whether `oled_tasklist` is empty, if not it will execute the first task in oled_tasklist at a time, and delete that task later

