### PR TITLE
Strip camera control behavior from UI logic layer

### DIFF
--- a/src/camera.py
+++ b/src/camera.py
@@ -35,8 +35,19 @@ class Sony_multi:
         print(str(time.ticks_us()) + " [Create] UART2")
         self.uart = target.init_uart2()
         print(str(time.ticks_us()) + " [  OK  ] UART2")
-        print(str(time.ticks_us()) + " [Create] Sony MTP object")
-    
+        self.transation_time = 0
+        print(str(time.ticks_us()) + " [  OK  ] Sony MTP object")
+
+    def rec(self):
+        self.transation_time += 5
+        if self.transation_time == 500:
+            self.rec_press()
+        elif self.transation_time > 500 and self.transation_time < 1000:
+            pass
+        elif self.transation_time >= 1000:
+            self.rec_release()
+            self.transation_time = 0
+
     def rec_press(self):
         self.uart.write(self.REC_PRESS)
         print("shutter send: ", self.REC_PRESS)
@@ -67,32 +78,93 @@ class Sony_multi:
                 vram.arm_state = "arm"
                 await swriter.awrite(self.REC_START_ACK)
                 vram.shutter_state = "recording"
+                self.transation_time = 0
 
             elif data == self.REC_STOP:
                 await asyncio.sleep_ms(8)
                 vram.arm_state = "disarm"
                 await swriter.awrite(self.REC_STOP_ACK)
                 vram.shutter_state = "idle"
+                self.transation_time = 0
 
 
 class Momentary_ground:
     def __init__(self):
+        print(str(time.ticks_us()) + " [Create] Momentary ground object")
         self.pin = target.init_momentary_ground_pin()
-    
+        self.transation_time = 0
+        print(str(time.ticks_us()) + " [  OK  ] Momentary ground object")
+
+    def rec(self):
+        self.transation_time += 5
+        if self.transation_time == 100:
+            self.momentary_ground(0) # ground
+        elif self.transation_time > 100 and self.transation_time < 1000:
+            pass
+        elif self.transation_time >= 1000:
+            self.momentary_ground(1) # OD
+            print(vram.shutter_state)
+            self.transation_time = 0
+
     def momentary_ground(self,value):
         # 1 High impedance (open drain)
-        # 0 Low voltage (tied to ground)    
+        # 0 Low voltage (tied to ground)
         self.pin.value(value)
+        if value == 1:
+            if vram.shutter_state == "stopping":
+                vram.shutter_state = "idle"
+                vram.arm_state = "disarm"
+            elif vram.shutter_state == "starting":
+                vram.shutter_state = "recording"
+                vram.arm_state = "arm"
 
 
 class Schmitt_3v3:
     def __init__(self):
+        print(str(time.ticks_us()) + " [Create] Schmitt 3v3 object")
         self.pin = target.init_schmitt_3v3_trigger_pin()
-    
+        self.transation_time = 0
+        print(str(time.ticks_us()) + " [  OK  ] Schmitt 3v3 object")
+
+    def rec(self):
+        self.transation_time += 5
+        if self.transation_time >= 1000:
+            self.transation_time = 0
+            toggle_cc_voltage_level()
+
     def toggle_cc_voltage_level(self):
-        if vram.shutter_state == "recording":
-            self.pin.value(1)
-            print("high voltarge level")
-        else:
+        if vram.shutter_state == "stopping":
+            vram.shutter_state = "idle"
             self.pin.value(0)
-            print("low voltage level")
+            vram.arm_state = "disarm"
+        elif vram.shutter_state == "starting":
+            vram.shutter_state = "recording"
+            self.pin.value(1)
+            vram.arm_state = "arm"
+
+
+class No_Cam:
+    def __init__(self):
+        print(str(time.ticks_us()) + " [Create] No camera object")
+        self.transation_time = 0
+        print(str(time.ticks_us()) + " [  OK  ] No camera object")
+
+    def rec(self):
+        self.transation_time += 5
+        if self.transation_time <= 1000:
+            pass
+        elif self.transation_time == 1000:
+            pass
+        elif self.transation_time >= 1000:
+            self.no_cam()
+            print(vram.shutter_state)
+            self.transation_time = 0
+
+    def no_cam(self):
+        if vram.shutter_state == "starting":
+            vram.shutter_state = "recording"
+            vram.arm_state = "arm"
+        elif vram.shutter_state == "stopping":
+            vram.shutter_state = "idle"
+            vram.arm_state = "disarm"
+

--- a/src/entry.py
+++ b/src/entry.py
@@ -16,8 +16,9 @@
 import machine as machine
 machine.freq(240000000)
 
-import task, settings
+import settings
 settings.read()
+import task
 task = task.Task()
 
 from machine import Timer
@@ -26,9 +27,8 @@ timer0.init(period=5, mode=Timer.PERIODIC, callback=task.schedular)
 
 import vram
 if vram.camera_protocol == "Sony MTP":
-    import camera
     import uasyncio as asyncio
-    camera_uart_handler = camera.Sony_multi().uart_handler()
+    camera_uart_handler = task.ui.camera.uart_handler()
     loop = asyncio.get_event_loop()
     loop.create_task(camera_uart_handler)
     loop.run_forever()

--- a/src/settings.py
+++ b/src/settings.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with flowshutter.  If not, see <https://www.gnu.org/licenses/>.
 import json, os
-import target, vram, camera
+import target, vram
 
 def _load_():
     with open("settings.json", "r") as f:

--- a/src/sha.json
+++ b/src/sha.json
@@ -14,7 +14,7 @@
         },
         {
             "name": "camera.py",
-            "sha1": "f8455d39e553299b491e7581b8136b73f7ec60b2"
+            "sha1": "428e64422eb14713bc92396d4ec3167d43a6871c"
         },
         {
             "name": "canvas.py",
@@ -26,7 +26,7 @@
         },
         {
             "name": "entry.py",
-            "sha1": "8230535d7409416cd7bc6d3d5994f71349e60691"
+            "sha1": "211b7c84b3c82d55fd912d3d022de6e67a6bb1d0"
         },
         {
             "name": "main.py",
@@ -42,7 +42,7 @@
         },
         {
             "name": "settings.py",
-            "sha1": "e45ba6d8e8bdf1f99d0af844b305cb9c2240fbfa"
+            "sha1": "492c7bfdc7f4a728d91bea0c73ebe79b45275d48"
         },
         {
             "name": "ssd1306.py",
@@ -58,11 +58,11 @@
         },
         {
             "name": "task.py",
-            "sha1": "6b0b102600cce06425dc00e3810bdf320a13d24d"
+            "sha1": "a1802ddd20285c220b7150b10d0578edc98fd733"
         },
         {
             "name": "ui.py",
-            "sha1": "d485981198a1c0bdd4881848dfdf7306de7508de"
+            "sha1": "16e93dc34eafc6fe6a050cb11577ee23785cf1d3"
         },
         {
             "name": "urequests.py",

--- a/src/task.py
+++ b/src/task.py
@@ -13,7 +13,7 @@
 
 # You should have received a copy of the GNU Affero General Public License
 # along with flowshutter.  If not, see <https://www.gnu.org/licenses/>.
-import camera, crsf, vram, peripherals, ui
+import crsf, vram, peripherals, ui
 import time, gc
 
 class Task:


### PR DESCRIPTION
A `rec()` method is added to the all class in `camera.py`, and the `UI` only needs to use its `rec()` method for the abstract camera to complete the REC control of the camera.