### PR TITLE
improve ssd1306 driver

### DIFF
--- a/src/entry.py
+++ b/src/entry.py
@@ -13,9 +13,6 @@
 
 # You should have received a copy of the GNU Affero General Public License
 # along with flowshutter.  If not, see <https://www.gnu.org/licenses/>.
-import machine as machine
-machine.freq(240000000)
-
 import settings
 settings.read()
 import task

--- a/src/sha.json
+++ b/src/sha.json
@@ -26,7 +26,7 @@
         },
         {
             "name": "entry.py",
-            "sha1": "211b7c84b3c82d55fd912d3d022de6e67a6bb1d0"
+            "sha1": "dcfb9bcf7f914d138474958aafc073df7c1675bc"
         },
         {
             "name": "main.py",
@@ -46,7 +46,7 @@
         },
         {
             "name": "ssd1306.py",
-            "sha1": "6125326ec8e972f6247a9340363a70a047038339"
+            "sha1": "1a8acf9f1961c220a3d192cc393e25b0efbe2337"
         },
         {
             "name": "startup.py",
@@ -54,7 +54,7 @@
         },
         {
             "name": "target.py",
-            "sha1": "27084cdff9bc9655354e87d5268998176ebe317d"
+            "sha1": "55f23bb2113381b8d579f78e6c936ca1d4cc1aa7"
         },
         {
             "name": "task.py",

--- a/src/target.py
+++ b/src/target.py
@@ -13,7 +13,10 @@
 
 # You should have received a copy of the GNU Affero General Public License
 # along with flowshutter.  If not, see <https://www.gnu.org/licenses/>.
-from machine import UART, Pin, SoftI2C, ADC
+from machine import ADC
+from machine import I2C
+from machine import Pin
+from machine import UART
 import time
 
 def init_adc():
@@ -36,7 +39,7 @@ def init_audio():
 
 def init_i2c():
     print(str(time.ticks_us()) + " [ Init ] I2C")
-    i2c = SoftI2C(scl=Pin(22), sda=Pin(21), freq = 400000)
+    i2c = I2C(0, scl=Pin(22), sda=Pin(21), freq = 1000000)
     return i2c
 
 def init_buttons():


### PR DESCRIPTION
Revert https://github.com/gyroflow/flowshutter/pull/122.

In the previous driver, since `write_data()` was implemented based on the `SoftI2C()`, the clock frequency of the latter was largely dependent on the CPU frequency, which caused a great performance hindrance to the entire project.

Under the chip frequency of 240MHz, the actual clock frequency of I2C SCL can only reach about 370KHz, which makes us have to transfer only half a line of the page (64 bytes) at a time, so as to ensure that there is enough time to process other affairs after the `show_sub()` task. The duration of this idle state is approximately 1.57ms.

![image](https://user-images.githubusercontent.com/31283897/169457369-93859342-6cf8-4d74-bd0b-eb0c80e85bd9.png)

This PR rewrites the `write_data()` method which uses the `writeto()` method provided by `I2C()` to replace the `start()`, `write()` and `stop()` methods of the original `SoftI2C()`.

Although hardware I2C will cause a large blocking time after a single transmission (only compared to software I2C, the blocking time of the entire task system is negligible),  we can pull the SCL clock frequency to 1MHz to increase the transfer rate. The actual SCL frequency is about 770KHz, which is more than double the original 370KHz!

Since the SCL clock frequency has been doubled, we can reconsider transferring an entire row of pages (128bytes) at a time. The actual test is that there is still about 1.41ms of idle time after the show_sub() task.

Also, 240Mhz was removed as it was no longer urgently needed. The default frequency is about 160Mhz. This has no impact on performance.

![image](https://user-images.githubusercontent.com/31283897/169456726-f352cefb-1f5f-4a2b-90fc-dde9832e4bc2.png)
